### PR TITLE
generating a service account and related clusterrole in default namespace

### DIFF
--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: experiment-sa
+  labels:
+    name: experiment-sa
+---
+# Source: openebs/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: experiment
+  labels:
+    name: experiment
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: experiment
+  labels:
+    name: experiment
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: experiment
+subjects:
+- kind: ServiceAccount
+  name: experiment-sa
+  namespace: default

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -13,9 +13,25 @@ metadata:
   labels:
     name: experiment
 rules:
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
+- apiGroups: 
+    - ""
+    - "extensions"
+    - "apps"
+    - "batch"
+    - "litmuschaos.io"
+  resources:
+    - "daemonsets"
+    - "deployments"
+    - "replicasets"
+    - "jobs"
+    - "pods"
+    - "pods/exec"
+    - "events"
+    - "chaosengines"
+    - "chaosexperiments"
+    - "chaosresults"
+  verbs:
+    - "*"
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding


### PR DESCRIPTION
This PR will create following in `default` namespace

- ServiceAccount name `experiment-sa`

- ClusterRole named `experiment`

- ClusterRoleBinding named `experiment`

Signed-off-by: sanjay1611 <sanjay.nathani@mayadata.io>